### PR TITLE
Fix bug user can add project or task with empty string

### DIFF
--- a/app/src/main/java/com/example/projectprogresstracker/MainActivity.java
+++ b/app/src/main/java/com/example/projectprogresstracker/MainActivity.java
@@ -204,8 +204,12 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
                     btnCreate.setOnClickListener(new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
-                            addProject(edtAddProjectName.getText().toString());
-                            dialogAddProject.dismiss();
+                            if(!edtAddProjectName.getText().toString().isEmpty()) {
+                                addProject(edtAddProjectName.getText().toString());
+                                dialogAddProject.dismiss();
+                            } else {
+                                Toast.makeText(MainActivity.this, "Project name couldn't be empty", Toast.LENGTH_SHORT).show();
+                            }
                         }
                     });
 

--- a/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
@@ -145,9 +145,13 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                 btnCreate.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        Toast.makeText(getApplicationContext(), edtAddTaskName.getText().toString(), Toast.LENGTH_SHORT).show();
-                        addTask(edtAddTaskName.getText().toString());
-                        dialogAddProject.dismiss();
+                        if (!edtAddTaskName.getText().toString().isEmpty()) {
+                            Toast.makeText(getApplicationContext(), edtAddTaskName.getText().toString(), Toast.LENGTH_SHORT).show();
+                            addTask(edtAddTaskName.getText().toString());
+                            dialogAddProject.dismiss();
+                        } else {
+                            Toast.makeText(ProjectDetails.this, "Task name couldn't be empty", Toast.LENGTH_SHORT).show();
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Hi,
I've added a condition for checking project or task name is empty. So the user can't add project or task name with empty string.
This PR for hacktoberfest purpose :smiley:  