### PR TITLE
Rename task/activity/project

### DIFF
--- a/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
+++ b/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
@@ -29,7 +29,7 @@ import static com.example.projectprogresstracker.data.ProjectContract.ProjectEnt
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_ACTIVITY_NAME;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_ACTIVITY_PROGRESS;
 
-public class Activity_details extends AppCompatActivity implements AdapterView.OnItemSelectedListener {
+public class Activity_details extends AppCompatActivity implements AdapterView.OnItemSelectedListener, AlertDialogCallbacks {
     int mId;
     SQLiteDatabase writableTaskDb, readableTaskDb;
     ProjectDbHelper projectDbHelper;
@@ -152,6 +152,22 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
         queryActivity();
     }
 
+    public void updateActivityName(String activityName) {
+        ContentValues values = new ContentValues();
+        values.put(COLUMN_ACTIVITY_NAME, activityName);
+        // Which row to update, based on the title
+        String selection = ACTIVITY_ID + " LIKE ?";
+        String[] selectionArgs = {String.valueOf(mId)};
+        int count = writableTaskDb.update(
+                ACTIVITY_TABLE_NAME,
+                values,
+                selection,
+                selectionArgs);
+
+        queryActivity();
+    }
+
+
     /**
      * back botton
      */
@@ -184,7 +200,7 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                AlertDialogService.getInstance().showAlertDialogToRename(Activity_details.this, "Activity", tvActivityName);
+                                AlertDialogService.getInstance().showAlertDialogToRename(Activity_details.this, "Activity", tvActivityName, Activity_details.this);
                                 return true;
                             default:
                                 return true;
@@ -196,5 +212,16 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
         popup.show();
 
     }
+
+    @Override
+    public void onPositiveAlertDialogOption(String changedName) {
+        updateActivityName(changedName);
+    }
+
+    @Override
+    public void onNegativeAlertDialogOption() {
+
+    }
+
 }
 

--- a/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
+++ b/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
@@ -184,7 +184,7 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                AlertDialogService.getInstance().showAlertDialogToRename(Activity_details.this, tvActivityName);
+                                AlertDialogService.getInstance().showAlertDialogToRename(Activity_details.this, "Activity", tvActivityName);
                                 return true;
                             default:
                                 return true;

--- a/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
+++ b/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
@@ -184,7 +184,7 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                presentAlertDialogForRenamingTask();
+                                AlertDialogService.getInstance().showAlertDialogToRename(Activity_details.this, tvActivityName);
                                 return true;
                             default:
                                 return true;
@@ -195,31 +195,6 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
                 });
         popup.show();
 
-    }
-
-
-    private void presentAlertDialogForRenamingTask() {
-        AlertDialog.Builder alert = new AlertDialog.Builder(this);
-        final EditText editText = new EditText(this);
-        alert.setMessage("Enter the new name of the task");
-        alert.setTitle("Rename Current Task");
-
-        alert.setView(editText);
-
-        alert.setPositiveButton("Yes Option", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                String text = editText.getText().toString();
-                tvActivityName.setText(text);
-            }
-        });
-
-        alert.setNegativeButton("No Option", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                // what ever you want to do with No option.
-            }
-        });
-
-        alert.show();
     }
 }
 

--- a/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
+++ b/app/src/main/java/com/example/projectprogresstracker/Activity_details.java
@@ -1,18 +1,22 @@
 package com.example.projectprogresstracker;
 
 import android.content.ContentValues;
+import android.content.DialogInterface;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
+import android.text.Editable;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.PopupMenu;
 
@@ -180,7 +184,7 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                Toast.makeText(getApplicationContext(), "rename Clicked", Toast.LENGTH_SHORT).show();
+                                presentAlertDialogForRenamingTask();
                                 return true;
                             default:
                                 return true;
@@ -191,6 +195,31 @@ public class Activity_details extends AppCompatActivity implements AdapterView.O
                 });
         popup.show();
 
+    }
+
+
+    private void presentAlertDialogForRenamingTask() {
+        AlertDialog.Builder alert = new AlertDialog.Builder(this);
+        final EditText editText = new EditText(this);
+        alert.setMessage("Enter the new name of the task");
+        alert.setTitle("Rename Current Task");
+
+        alert.setView(editText);
+
+        alert.setPositiveButton("Yes Option", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                String text = editText.getText().toString();
+                tvActivityName.setText(text);
+            }
+        });
+
+        alert.setNegativeButton("No Option", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                // what ever you want to do with No option.
+            }
+        });
+
+        alert.show();
     }
 }
 

--- a/app/src/main/java/com/example/projectprogresstracker/AlertDialogCallbacks.java
+++ b/app/src/main/java/com/example/projectprogresstracker/AlertDialogCallbacks.java
@@ -1,0 +1,8 @@
+package com.example.projectprogresstracker;
+
+interface AlertDialogCallbacks {
+
+    void onPositiveAlertDialogOption(String changedName);
+
+    void onNegativeAlertDialogOption();
+}

--- a/app/src/main/java/com/example/projectprogresstracker/AlertDialogService.java
+++ b/app/src/main/java/com/example/projectprogresstracker/AlertDialogService.java
@@ -18,24 +18,24 @@ class AlertDialogService {
 
     }
 
-    public void showAlertDialogToRename(Context context, String type, final TextView textViewToUpdate) {
+    public void showAlertDialogToRename(Context context, String type, final TextView textViewToUpdate, final AlertDialogCallbacks callbacks) {
         AlertDialog.Builder alert = new AlertDialog.Builder(context);
         final EditText editText = new EditText(context);
         alert.setMessage("Enter the new name of the " + type);
         alert.setTitle("Rename Current " + type);
 
         alert.setView(editText);
-
         alert.setPositiveButton("Done", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String text = editText.getText().toString();
                 textViewToUpdate.setText(text);
+                callbacks.onPositiveAlertDialogOption(text);
             }
         });
 
         alert.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
-                // what ever you want to do with No option.
+                callbacks.onNegativeAlertDialogOption();
             }
         });
 

--- a/app/src/main/java/com/example/projectprogresstracker/AlertDialogService.java
+++ b/app/src/main/java/com/example/projectprogresstracker/AlertDialogService.java
@@ -1,0 +1,44 @@
+package com.example.projectprogresstracker;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+
+class AlertDialogService {
+    private static final AlertDialogService ourInstance = new AlertDialogService();
+
+    static AlertDialogService getInstance() {
+        return ourInstance;
+    }
+
+    private AlertDialogService() {
+
+    }
+
+    public void showAlertDialogToRename(Context context, final TextView textViewToUpdate) {
+        AlertDialog.Builder alert = new AlertDialog.Builder(context);
+        final EditText editText = new EditText(context);
+        alert.setMessage("Enter the new name of the task");
+        alert.setTitle("Rename Current Task");
+
+        alert.setView(editText);
+
+        alert.setPositiveButton("Done", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                String text = editText.getText().toString();
+                textViewToUpdate.setText(text);
+            }
+        });
+
+        alert.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                // what ever you want to do with No option.
+            }
+        });
+
+        alert.show();
+    }
+}

--- a/app/src/main/java/com/example/projectprogresstracker/AlertDialogService.java
+++ b/app/src/main/java/com/example/projectprogresstracker/AlertDialogService.java
@@ -18,11 +18,11 @@ class AlertDialogService {
 
     }
 
-    public void showAlertDialogToRename(Context context, final TextView textViewToUpdate) {
+    public void showAlertDialogToRename(Context context, String type, final TextView textViewToUpdate) {
         AlertDialog.Builder alert = new AlertDialog.Builder(context);
         final EditText editText = new EditText(context);
-        alert.setMessage("Enter the new name of the task");
-        alert.setTitle("Rename Current Task");
+        alert.setMessage("Enter the new name of the " + type);
+        alert.setTitle("Rename Current " + type);
 
         alert.setView(editText);
 

--- a/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
@@ -4,6 +4,7 @@ import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
@@ -613,7 +614,7 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                Toast.makeText(getApplicationContext(), "rename Clicked", Toast.LENGTH_SHORT).show();
+                                presentAlertDialogForRenamingTask();
                                 return true;
                             default:
                                 return true;
@@ -624,5 +625,29 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                 });
         popup.show();
 
+    }
+
+    private void presentAlertDialogForRenamingTask() {
+        AlertDialog.Builder alert = new AlertDialog.Builder(this);
+        final EditText editText = new EditText(this);
+        alert.setMessage("Enter the new name of the task");
+        alert.setTitle("Rename Current Task");
+
+        alert.setView(editText);
+
+        alert.setPositiveButton("Done", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                String text = editText.getText().toString();
+                tvProjectName.setText(text);
+            }
+        });
+
+        alert.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                // what ever you want to do with No option.
+            }
+        });
+
+        alert.show();
     }
 }

--- a/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
@@ -614,7 +614,7 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                AlertDialogService.getInstance().showAlertDialogToRename(ProjectDetails.this, tvProjectName);
+                                AlertDialogService.getInstance().showAlertDialogToRename(ProjectDetails.this, "Project", tvProjectName);
                                 return true;
                             default:
                                 return true;

--- a/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
@@ -614,7 +614,7 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                presentAlertDialogForRenamingTask();
+                                AlertDialogService.getInstance().showAlertDialogToRename(ProjectDetails.this, tvProjectName);
                                 return true;
                             default:
                                 return true;
@@ -625,29 +625,5 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                 });
         popup.show();
 
-    }
-
-    private void presentAlertDialogForRenamingTask() {
-        AlertDialog.Builder alert = new AlertDialog.Builder(this);
-        final EditText editText = new EditText(this);
-        alert.setMessage("Enter the new name of the task");
-        alert.setTitle("Rename Current Task");
-
-        alert.setView(editText);
-
-        alert.setPositiveButton("Done", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                String text = editText.getText().toString();
-                tvProjectName.setText(text);
-            }
-        });
-
-        alert.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                // what ever you want to do with No option.
-            }
-        });
-
-        alert.show();
     }
 }

--- a/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/ProjectDetails.java
@@ -56,7 +56,7 @@ import static com.example.projectprogresstracker.data.ProjectContract.ProjectEnt
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.TASK_ID;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.TASK_TABLE_NAME;
 
-public class ProjectDetails extends AppCompatActivity implements AdapterView.OnItemClickListener {
+public class ProjectDetails extends AppCompatActivity implements AdapterView.OnItemClickListener, AlertDialogCallbacks {
     ExpandableLayout expandablelayout2;
     ImageView expandCollapseArrow2;
     TextView edtStartDate, edtEndDate, tvProjectName, tvDaysLeft, tvProjectTarget, tvProjectDescription, tvProjectProgress;
@@ -600,6 +600,21 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
 //
     }
 
+    public void updateProjectName(String projectName) {
+        ContentValues values = new ContentValues();
+        values.put(COLUMN_PROJECT_NAME, projectName);
+        // Which row to update, based on the title
+        String selection = ProjectContract.ProjectEntry._ID + " LIKE ?";
+        String[] selectionArgs = {String.valueOf(mId)};
+        int count = writableProjectDb.update(
+                TABLE_NAME,
+                values,
+                selection,
+                selectionArgs);
+
+        queryProject();
+    }
+
     public void loadOptions(View view) {
 
         PopupMenu popup = new PopupMenu(this, view);
@@ -614,7 +629,7 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                AlertDialogService.getInstance().showAlertDialogToRename(ProjectDetails.this, "Project", tvProjectName);
+                                AlertDialogService.getInstance().showAlertDialogToRename(ProjectDetails.this, "Project", tvProjectName, ProjectDetails.this);
                                 return true;
                             default:
                                 return true;
@@ -624,6 +639,16 @@ public class ProjectDetails extends AppCompatActivity implements AdapterView.OnI
                     // implement click listener.
                 });
         popup.show();
+
+    }
+
+    @Override
+    public void onPositiveAlertDialogOption(String changedName) {
+        updateProjectName(changedName);
+    }
+
+    @Override
+    public void onNegativeAlertDialogOption() {
 
     }
 }

--- a/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
@@ -431,7 +431,7 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                AlertDialogService.getInstance().showAlertDialogToRename(TaskDetails.this, tvTaskName);
+                                AlertDialogService.getInstance().showAlertDialogToRename(TaskDetails.this, "Task", tvTaskName);
                                 return true;
                             default:
                                 return true;

--- a/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
@@ -25,6 +25,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.PopupMenu;
 
+import com.example.projectprogresstracker.data.ProjectContract;
 import com.example.projectprogresstracker.data.ProjectDbHelper;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.skydoves.progressview.ProgressView;
@@ -40,14 +41,16 @@ import static com.example.projectprogresstracker.data.ProjectContract.ProjectEnt
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_ACTIVITY_NAME;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_ACTIVITY_PROGRESS;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_ACTIVITY_TASK_ID;
+import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_PROJECT_NAME;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_TASK_DESCRIPTION;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_TASK_END_DATE;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_TASK_NAME;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.COLUMN_TASK_PROGRESS;
+import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.TABLE_NAME;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.TASK_ID;
 import static com.example.projectprogresstracker.data.ProjectContract.ProjectEntry.TASK_TABLE_NAME;
 
-public class TaskDetails extends AppCompatActivity implements AdapterView.OnItemClickListener {
+public class TaskDetails extends AppCompatActivity implements AdapterView.OnItemClickListener, AlertDialogCallbacks {
 
     int mId;
     SQLiteDatabase writableTaskDb, readableTaskDb;
@@ -333,6 +336,21 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
         queryTask();
     }
 
+    public void updateTaskName(String taskName) {
+        ContentValues values = new ContentValues();
+        values.put(COLUMN_TASK_NAME, taskName);
+        // Which row to update, based on the title
+        String selection = TASK_ID + " LIKE ?";
+        String[] selectionArgs = {String.valueOf(mId)};
+        int count = writableTaskDb.update(
+                TASK_TABLE_NAME,
+                values,
+                selection,
+                selectionArgs);
+
+        queryTask();
+    }
+
     public void addActivity(String activityName) {
         int mStartYear = calender.get(Calendar.YEAR);
         int mStartMonth = calender.get(Calendar.MONTH) + 1;
@@ -431,7 +449,7 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                AlertDialogService.getInstance().showAlertDialogToRename(TaskDetails.this, "Task", tvTaskName);
+                                AlertDialogService.getInstance().showAlertDialogToRename(TaskDetails.this, "Task", tvTaskName, TaskDetails.this);
                                 return true;
                             default:
                                 return true;
@@ -441,6 +459,16 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
                     // implement click listener.
                 });
         popup.show();
+
+    }
+
+    @Override
+    public void onPositiveAlertDialogOption(String changedName) {
+        updateTaskName(changedName);
+    }
+
+    @Override
+    public void onNegativeAlertDialogOption() {
 
     }
 

--- a/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
@@ -431,7 +431,7 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                presentAlertDialogForRenamingTask();
+                                AlertDialogService.getInstance().showAlertDialogToRename(TaskDetails.this, tvTaskName);
                                 return true;
                             default:
                                 return true;
@@ -442,30 +442,6 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
                 });
         popup.show();
 
-    }
-
-    private void presentAlertDialogForRenamingTask() {
-        AlertDialog.Builder alert = new AlertDialog.Builder(this);
-        final EditText editText = new EditText(this);
-        alert.setMessage("Enter the new name of the task");
-        alert.setTitle("Rename Current Task");
-
-        alert.setView(editText);
-
-        alert.setPositiveButton("Done", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                String text = editText.getText().toString();
-                tvTaskName.setText(text);
-            }
-        });
-
-        alert.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                // what ever you want to do with No option.
-            }
-        });
-
-        alert.show();
     }
 
 }

--- a/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
+++ b/app/src/main/java/com/example/projectprogresstracker/TaskDetails.java
@@ -4,6 +4,7 @@ import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
@@ -430,7 +431,7 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
                                 Toast.makeText(getApplicationContext(), "delete Clicked", Toast.LENGTH_SHORT).show();
                                 return true;
                             case R.id.option_rename:
-                                Toast.makeText(getApplicationContext(), "rename Clicked", Toast.LENGTH_SHORT).show();
+                                presentAlertDialogForRenamingTask();
                                 return true;
                             default:
                                 return true;
@@ -441,6 +442,30 @@ public class TaskDetails extends AppCompatActivity implements AdapterView.OnItem
                 });
         popup.show();
 
+    }
+
+    private void presentAlertDialogForRenamingTask() {
+        AlertDialog.Builder alert = new AlertDialog.Builder(this);
+        final EditText editText = new EditText(this);
+        alert.setMessage("Enter the new name of the task");
+        alert.setTitle("Rename Current Task");
+
+        alert.setView(editText);
+
+        alert.setPositiveButton("Done", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                String text = editText.getText().toString();
+                tvTaskName.setText(text);
+            }
+        });
+
+        alert.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int whichButton) {
+                // what ever you want to do with No option.
+            }
+        });
+
+        alert.show();
     }
 
 }


### PR DESCRIPTION
To allow users to be able to rename their tasks/activities/projects, an AlertDialogService class was created and an interface to allow for callbacks depending on the user's choice.

Furthermore, to make sure the changed named will be saved between sessions, methods to save the new name in the DB were created for activity, task and project.

Fixes #5 

![95001865-dd5e0a00-05d6-11eb-8f7b-1bd449aafd76](https://user-images.githubusercontent.com/23402988/95024170-1c00cc80-068a-11eb-9115-e8687d5a5be5.png)
